### PR TITLE
Fix cases where the 'eavesdroppings' array is undefined; also persist when adding

### DIFF
--- a/src/eavesdrop.coffee
+++ b/src/eavesdrop.coffee
@@ -26,10 +26,11 @@ class EavesDropping
     @recentEvents = {}
   add: (pattern, user, action, order) ->
     task = {key: pattern, task: action, order: order, creator: user}
-    @eavesdroppings = @eavesdroppings or @robot.brain.get 'eavesdroppings'
+    @eavesdroppings = @eavesdroppings or @robot.brain.get('eavesdroppings') or []
     @eavesdroppings.push task
+    @robot.brain.set 'eavesdroppings', @eavesdroppings
   all: ->
-    @eavesdroppings or @robot.brain.get 'eavesdroppings'
+    @eavesdroppings or @robot.brain.get('eavesdroppings') or []
   deleteByPattern: (pattern, msg) ->
     @eavesdroppings = @eavesdroppings or @robot.brain.get 'eavesdroppings'
     filtered = @eavesdroppings.filter (n) -> n.key != pattern


### PR DESCRIPTION
In a fresh CFPBot instance, `@eavesdroppings` won't be initialized, so `all()` will raise an exception in `hear`. Same thing will happen when `add()` is called for the first time.

Then I noticed that the listeners I was adding weren't being persisted in the brain. At least it sure didn't seem like it. I could be missing something there. I also might just have something wrong in my local setup, since I'm attempting to get the bot working under Docker. That said, it seems like the container with the bot is talking to the redis container without problems -- so far anyway.

I was also wondering: why not just init `@eavesdroppings` in the constructor instead of adding those `or []`s everywhere? Seems like it would make more sense, but I avoided that since I'm not sure if there'd be a race condition. What if redis-brain hadn't spun up before the eavesdropper had started? I guess I don't know the order of operations, and don't know enough about how hubot works.